### PR TITLE
ci(release): switch Release workflow to manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,11 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  # Manual trigger for now. Re-enable `push: branches: [main]` once (1) a trusted
+  # publisher is configured on npmjs.com for each @ark/* package and (2) GitHub
+  # Actions is allowed to create pull requests
+  # (Settings → Actions → General → Workflow permissions).
+  workflow_dispatch:
 
 # OIDC trusted publishing to npm (no long-lived NPM_TOKEN). Requires a trusted
 # publisher to be configured on npmjs.com for each @ark/* package before the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,16 @@ changes bump the minor and reuse the file; breaking changes publish a new
 
 ## Releasing
 
-Releases are automated with **Changesets** and published to npm via **OIDC
-trusted publishing** (no `NPM_TOKEN`). Before the first publish, a trusted
-publisher must be configured on npmjs.com for each `@ark/*` package, pointing at
-`.github/workflows/release.yml`. Merging the bot's “Version Packages” PR then
-publishes the bumped packages with provenance attestations.
+Releases use **Changesets** and publish to npm via **OIDC trusted publishing**
+(no `NPM_TOKEN`). Merging the “Version Packages” PR publishes the bumped packages
+with provenance attestations.
+
+The Release workflow is currently **manually dispatched** (Actions → Release →
+Run workflow). Before switching its trigger back to `push` (auto-release), two
+prerequisites must be in place:
+
+1. a trusted publisher configured on npmjs.com for each `@ark/*` package,
+   pointing at `.github/workflows/release.yml`; and
+2. **Settings → Actions → General → Workflow permissions →** “Allow GitHub
+   Actions to create and approve pull requests” enabled (Changesets opens the
+   “Version Packages” PR).


### PR DESCRIPTION
The Release workflow failed on every push to `main` with **"GitHub Actions is not permitted to create or approve pull requests"** — Changesets could not open its "Version Packages" PR.

Nothing is published yet (no npm trusted publisher configured), so this gates the workflow behind `workflow_dispatch` to stop the failing runs on main. `CONTRIBUTING.md` documents the two prerequisites to re-enable auto-release (`push`):

1. a trusted publisher on npmjs.com for each `@ark/*` package;
2. **Settings → Actions → General →** "Allow GitHub Actions to create and approve pull requests".

No functional/runtime change — CI (build/test/lint/schema) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)