### PR TITLE
docs(readme): correct two claims the code does not back

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ARK follows five strict principles:
    Every hard failure should include precise reason and next action.
 
 3. **Noise suppression without blindness**  
-   Stale and low-signal events are filtered, but true burst behavior is surfaced early.
+   Low-signal noise is suppressed and true burst behavior is surfaced early.
 
 4. **Composable by design**  
    Teams can adopt only what they need: sanitize, classify, policy, report.
@@ -128,7 +128,7 @@ ARK consumes runtime events with standardized fields (see the
 - session and turn metadata
 - provider/model context
 - request/response envelope
-- error payload and stack hints
+- error payload
 - recent-window context for burst/noise detection
 
 ## Output Model


### PR DESCRIPTION
Two present-tense README statements described behavior that isn't implemented. Verified against the code/schema:

**1. Product Philosophy #3 — "Stale and low-signal events are filtered"** (factually wrong + self-contradictory)
Time/age-based stale filtering does not exist. `packages/classify/src/index.ts` only does recent-window **burst** detection (`countBurst`, `DEFAULT_BURST_THRESHOLD = 3`); there is no `Date.now`/age logic anywhere in `packages/*/src`. The README's own Roadmap already lists the *"stale-noise (time-based) gate"* as **pending**.
→ Reworded to *"Low-signal noise is suppressed and true burst behavior is surfaced early."*

**2. Input Model — "error payload and stack hints"** (no such field)
`runtimeError` in `schemas/runtime-event.v2.json` defines exactly `{ type, message, status, code, retryable }` with `additionalProperties: false`, matching `RuntimeError` in `packages/core/src/index.ts`. A `stack` payload would be **rejected by schema validation**.
→ Dropped *"and stack hints"*.

Docs-only; no code or schema change.